### PR TITLE
Fix the zookeeper image stream name

### DIFF
--- a/ansible/roles/project_zookeeper_openshift/templates/project_zookeeper_deployment_config.yml
+++ b/ansible/roles/project_zookeeper_openshift/templates/project_zookeeper_deployment_config.yml
@@ -47,7 +47,7 @@ spec:
           - zookeeper
         from:
           kind: ImageStreamTag
-          name: 'computate-zookeeper:latest'
+          name: 'zookeeper:latest'
           namespace: {{ZOOKEEPER_NAMESPACE}}
       type: ImageChange
     - type: ConfigChange


### PR DESCRIPTION
Missed a computate

With this I was able to get a zookeeper deployment config up and running with this command:

`ansible-playbook  -i /usr/local/src/opendatapolicing-ansible/inventories/opendatapolicing-hackathon/hosts  /usr/local/src/opendatapolicing/ansible/project_zookeeper_openshift.yml -e "ZOOKEEPER_HOST=https://api.shared-na4.na4.openshift.opentlc.com:6443" -e ZOOKEEPER_NAMESPACE=opendatapolicing -e ZOOKEEPER_TOKEN=...`